### PR TITLE
Pass event to button click handler

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -25,9 +25,9 @@ class Button extends Component {
   }
 
   @autobind
-  handleClick () {
+  handleClick (event) {
     if (this.props.isEnabled) {
-      this.props.onClick()
+      this.props.onClick(event)
     }
   }
 


### PR DESCRIPTION
This change passes the click event along to the handler. This is useful in scenarios where a button might be layered and need to call `stopPropagation` to prevent any further action.